### PR TITLE
fix: order bugs by identifier in get_bugs

### DIFF
--- a/elleelleaime/core/benchmarks/benchmark.py
+++ b/elleelleaime/core/benchmarks/benchmark.py
@@ -9,7 +9,7 @@ class Benchmark(ABC):
 
 import pathlib
 
-from typing import Dict, Set, Optional
+from typing import Dict, List, Optional
 from elleelleaime.core.benchmarks.bug import Bug
 
 
@@ -32,8 +32,8 @@ class Benchmark(ABC):
     def get_bin(self, options: str = "") -> Optional[str]:
         return None
 
-    def get_bugs(self) -> Set[Bug]:
-        return set(self.bugs.values())
+    def get_bugs(self) -> List[Bug]:
+        return sorted(list(self.bugs.values()))
 
     def get_bug(self, identifier) -> Optional[Bug]:
         return self.bugs[identifier]

--- a/elleelleaime/core/benchmarks/bug.py
+++ b/elleelleaime/core/benchmarks/bug.py
@@ -54,6 +54,9 @@ class Bug(ABC):
     def __repr__(self) -> str:
         return self.get_identifier()
 
+    def __lt__(self, other) -> bool:
+        return self.get_identifier() < other.get_identifier()
+
 
 class RichBug(Bug):
     """


### PR DESCRIPTION
Adds order to `get_bugs`.

Addresses reproducibility issues in tests (thank @cadddr).